### PR TITLE
Allow overriding FULL_DAY_DATA_CUTOFF_HOUR_UTC via parameter and persisted via appsettings.json

### DIFF
--- a/AzureDailyCostCompare.Tests/ProgramTests.cs
+++ b/AzureDailyCostCompare.Tests/ProgramTests.cs
@@ -12,7 +12,8 @@ public class ProgramTests
 
         // Arrange: Use a fixed reference date
         var referenceDate = new DateTime(2024, 01, 01);
-        var dateHelperService = new DateHelperService(referenceDate);
+        var cutoffHourUtc = 4;
+        var dateHelperService = new DateHelperService(cutoffHourUtc, referenceDate);
 
         // Arrange: Initialize the report generator
         var reportGenerator = new ReportGenerator(mockCostData, dateHelperService);
@@ -42,7 +43,8 @@ public class ProgramTests
 
         // Arrange: Use a fixed reference date
         var referenceDate = new DateTime(2024, 02, 10);
-        var dateHelperService = new DateHelperService(referenceDate);
+        var cutoffHourUtc = 4;
+        var dateHelperService = new DateHelperService(cutoffHourUtc, referenceDate);
 
         // Arrange: Initialize the report generator
         var reportGenerator = new ReportGenerator(mockCostData, dateHelperService);

--- a/AzureDailyCostCompare/AzureDailyCostCompare.csproj
+++ b/AzureDailyCostCompare/AzureDailyCostCompare.csproj
@@ -25,8 +25,20 @@
 		<PackageTags>azure;daily;cost;compare</PackageTags>
 	</PropertyGroup>
 
+	<ItemGroup>
+	  <None Remove="appsettings.json" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <Content Include="appsettings.json">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	  </Content>
+	</ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0-preview.4.25258.110" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0-preview.4.25258.110" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 

--- a/AzureDailyCostCompare/CommandLineBuilder.cs
+++ b/AzureDailyCostCompare/CommandLineBuilder.cs
@@ -5,91 +5,140 @@ namespace AzureDailyCostCompare;
 
 public static class CommandLineBuilder
 {
-    public static ConfigurationService ConfigService { get; } = new ConfigurationService();
-
     public static RootCommand BuildCommandLine()
     {
-        var rootCommand = new RootCommand("Azure Daily Cost Comparison Tool") { Name = "azure-daily-cost-compare" };
+        var rootCommand = new RootCommand("Azure Daily Cost Comparison Tool")
+        {
+            Name = "azure-daily-cost-compare"
+        };
 
-        var dateOption = new Option<DateTime?>(
-            "--date",
-            "Optional reference date for the report (format: yyyy-MM-dd). If not provided, current date will be used.");
-        var weeklyPatternOption = new Option<bool>(
-            ["--weekly-pattern-analysis", "-wpa"],
-            "Show weekly pattern analysis comparing corresponding weekdays");
-        var dayOfWeekOption = new Option<bool>(
-            ["--day-of-week-averages", "-dowa"],
-            "Show day of week averages comparing cost trends by weekday");
-
-        var previousDayUtcDataLoadDelayHoursOption = new Option<int?>(
-            ["--previous-day-utc-data-load-delay", "-pdl"],
-            "Number of hours after midnight UTC used to determine when the previous day's Azure cost data is considered complete enough to load. For example, a value of 4 means data for the previous day is assumed complete at 04:00 UTC. Valid values: 0–23.");
+        var (dateOption, weeklyPatternOption, dayOfWeekOption, dataLoadDelayOption) = CreateCommandOptions();
 
         rootCommand.AddOption(dateOption);
         rootCommand.AddOption(weeklyPatternOption);
         rootCommand.AddOption(dayOfWeekOption);
-        rootCommand.AddOption(previousDayUtcDataLoadDelayHoursOption);
+        rootCommand.AddOption(dataLoadDelayOption);
 
-        rootCommand.SetHandler(async (DateTime? date, bool showWeeklyPatterns, bool showDayOfWeekAverages, int? previousDayUtcDataLoadDelayHoursCommandArg) =>
-        {
-            int previousDayUtcDataLoadDelayHours;
-
-            try
-            {
-                if (!previousDayUtcDataLoadDelayHoursCommandArg.HasValue)
-                {
-                    IConfiguration configuration = ConfigurationService.LoadConfiguration();
-                    ConfigurationService.ValidatePreviousDayUtcDataLoadDelayHours(configuration);
-                    previousDayUtcDataLoadDelayHours = configuration.GetValue<int>("AppSettings:PreviousDayUtcDataLoadDelayHours:Value");
-
-                }
-                else
-                {
-                    ConfigurationService.ValidatePreviousDayUtcDataLoadDelayHoursValue(previousDayUtcDataLoadDelayHoursCommandArg.Value);
-                    ConfigurationService.UpdatePreviousDayUtcDataLoadDelayHours(previousDayUtcDataLoadDelayHoursCommandArg.Value);
-
-                    previousDayUtcDataLoadDelayHours = previousDayUtcDataLoadDelayHoursCommandArg.Value;
-
-                    Console.ForegroundColor = ConsoleColor.Green;
-                    Console.WriteLine($"PreviousDayUtcDataLoadDelayHours value successfully updated to {previousDayUtcDataLoadDelayHoursCommandArg.Value} in {ConfigurationService.ConfigFileName}. New value will be used now and for subsequent executions.");
-                    Console.ResetColor();
-                }
-            }
-            catch (ConfigurationValidationException ex)
-            {
-                Console.ForegroundColor = ConsoleColor.Red;
-                Console.Error.WriteLine($"Error: {ex.Message}");
-                Console.ResetColor();
-                return;
-            }
-
-            // Then run the cost comparison if no validation errors
-            await RunCostComparisonAsync(date, showWeeklyPatterns, showDayOfWeekAverages, previousDayUtcDataLoadDelayHours);
-        }, dateOption, weeklyPatternOption, dayOfWeekOption, previousDayUtcDataLoadDelayHoursOption);
+        rootCommand.SetHandler(
+            async context => await ExecuteCommandAsync(
+                context.ParseResult.GetValueForOption(dateOption),
+                context.ParseResult.GetValueForOption(weeklyPatternOption),
+                context.ParseResult.GetValueForOption(dayOfWeekOption),
+                context.ParseResult.GetValueForOption(dataLoadDelayOption)
+            )
+        );
 
         return rootCommand;
     }
 
-    private static async Task RunCostComparisonAsync(DateTime? date, bool showWeeklyPatterns, bool showDayOfWeekAverages, int previousDayUtcDataLoadDelayHours)
+    private static (
+        Option<DateTime?> DateOption,
+        Option<bool> WeeklyPatternOption,
+        Option<bool> DayOfWeekOption,
+        Option<int?> DataLoadDelayOption
+    ) CreateCommandOptions()
+    {
+        return (
+            new Option<DateTime?>(
+                "--date",
+                "Optional reference date for the report (format: yyyy-MM-dd). If not provided, current date will be used."),
+
+            new Option<bool>(
+                aliases: ["--weekly-pattern-analysis", "-wpa"],
+                description: "Show weekly pattern analysis comparing corresponding weekdays"),
+
+            new Option<bool>(
+                aliases: ["--day-of-week-averages", "-dowa"],
+                description: "Show day of week averages comparing cost trends by weekday"),
+
+            new Option<int?>(
+                aliases: ["--previous-day-utc-data-load-delay", "-pdl"],
+                description: "Number of hours after midnight UTC used to determine when the previous day's Azure cost data is considered complete enough to load. For example, a value of 4 means data for the previous day is assumed complete at 04:00 UTC. Valid values: 0–23.")
+        );
+    }
+
+    private static async Task ExecuteCommandAsync(
+        DateTime? date,
+        bool showWeeklyPatterns,
+        bool showDayOfWeekAverages,
+        int? previousDayUtcDataLoadDelayHours)
     {
         try
         {
-            var accessToken = await AuthenticationService.GetAccessToken();
-            var billingAccountId = await BillingService.GetBillingAccountIdAsync(accessToken);
-            var dateHelper = date.HasValue ? new DateHelperService(previousDayUtcDataLoadDelayHours, date.Value) : new DateHelperService(previousDayUtcDataLoadDelayHours);
-            var costService = new CostService();
-            var costData = await costService.QueryCostManagementAPI(
-                accessToken,
-                billingAccountId,
-                dateHelper.FirstDayOfPreviousMonth,
-                dateHelper.DataReferenceDate);
-            new ReportGenerator(costData, dateHelper).GenerateDailyCostReport(showWeeklyPatterns, showDayOfWeekAverages);
+            int dataLoadDelayHours = ConfigureDataLoadDelayHours(previousDayUtcDataLoadDelayHours);
+            await RunCostComparisonAsync(date, showWeeklyPatterns, showDayOfWeekAverages, dataLoadDelayHours);
+        }
+        catch (ConfigurationValidationException ex)
+        {
+            DisplayError(ex.Message);
         }
         catch (Exception ex)
         {
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.WriteLine($"Error: {ex.Message}");
-            Console.ResetColor();
+            DisplayError(ex.Message);
         }
+    }
+
+    private static int ConfigureDataLoadDelayHours(int? commandLineValue)
+    {
+        if (!commandLineValue.HasValue)
+        {
+            // Load from configuration
+            IConfiguration configuration = ConfigurationManager.LoadConfiguration();
+            ConfigurationManager.ValidatePreviousDayUtcDataLoadDelayHours(configuration);
+            return configuration.GetValue<int>("AppSettings:PreviousDayUtcDataLoadDelayHours:Value");
+        }
+
+        // Use and save command line value
+        ConfigurationManager.ValidatePreviousDayUtcDataLoadDelayHoursValue(commandLineValue.Value);
+        ConfigurationManager.UpdatePreviousDayUtcDataLoadDelayHours(commandLineValue.Value);
+
+        DisplaySuccess($"PreviousDayUtcDataLoadDelayHours value successfully updated to {commandLineValue.Value} " +
+                      $"in {ConfigurationManager.ConfigFileName}. New value will be used now and for subsequent executions.");
+
+        return commandLineValue.Value;
+    }
+
+    private static async Task RunCostComparisonAsync(
+        DateTime? date,
+        bool showWeeklyPatterns,
+        bool showDayOfWeekAverages,
+        int previousDayUtcDataLoadDelayHours)
+    {
+        // Get authentication token
+        var accessToken = await AuthenticationService.GetAccessToken();
+
+        // Get billing account ID
+        var billingAccountId = await BillingService.GetBillingAccountIdAsync(accessToken);
+
+        // Create date helper (with optional reference date)
+        var dateHelper = date.HasValue
+            ? new DateHelperService(previousDayUtcDataLoadDelayHours, date.Value)
+            : new DateHelperService(previousDayUtcDataLoadDelayHours);
+
+        // Query cost data
+        var costService = new CostService();
+        var costData = await costService.QueryCostManagementAPI(
+            accessToken,
+            billingAccountId,
+            dateHelper.FirstDayOfPreviousMonth,
+            dateHelper.DataReferenceDate);
+
+        // Generate report
+        new ReportGenerator(costData, dateHelper)
+            .GenerateDailyCostReport(showWeeklyPatterns, showDayOfWeekAverages);
+    }
+
+    private static void DisplayError(string message)
+    {
+        Console.ForegroundColor = ConsoleColor.Red;
+        Console.Error.WriteLine($"Error: {message}");
+        Console.ResetColor();
+    }
+
+    private static void DisplaySuccess(string message)
+    {
+        Console.ForegroundColor = ConsoleColor.Green;
+        Console.WriteLine(message);
+        Console.ResetColor();
     }
 }

--- a/AzureDailyCostCompare/CommandLineBuilder.cs
+++ b/AzureDailyCostCompare/CommandLineBuilder.cs
@@ -55,7 +55,7 @@ public static class CommandLineBuilder
 
         var dataLoadDelayOption = new Option<int?>(
             aliases: ["--previous-day-utc-data-load-delay", "-pdl"],
-            description: "Number of hours after midnight UTC used to determine when the previous day's Azure cost data is considered complete enough to load. For example, a value of 4 means data for the previous day is assumed complete at 04:00 UTC. Valid values: 0–23. Setting this persists for current and future executions.")
+            description: "Number of hours after midnight UTC used to determine when the previous day's Azure cost data is considered complete enough to load. For example, a value of 4 means data for the previous day is assumed complete at 04:00 UTC. Valid values: 0–23. Setting is used now and persists for future executions.")
         {
             ArgumentHelpName = "int:0-23"
         };

--- a/AzureDailyCostCompare/CommandLineBuilder.cs
+++ b/AzureDailyCostCompare/CommandLineBuilder.cs
@@ -38,23 +38,29 @@ public static class CommandLineBuilder
         Option<int?> DataLoadDelayOption
     ) CreateCommandOptions()
     {
-        return (
-            new Option<DateTime?>(
-                "--date",
-                "Optional reference date for the report (format: yyyy-MM-dd). If not provided, current date will be used."),
+        var dateOption = new Option<DateTime?>(
+            "--date",
+            "Optional reference date for the report (format: yyyy-MM-dd). If not provided, current date will be used.")
+        {
+            ArgumentHelpName = "yyyy-MM-dd"
+        };
 
-            new Option<bool>(
-                aliases: ["--weekly-pattern-analysis", "-wpa"],
-                description: "Show weekly pattern analysis comparing corresponding weekdays"),
+        var weeklyPatternOption = new Option<bool>(
+            aliases: ["--weekly-pattern-analysis", "-wpa"],
+            description: "Show weekly pattern analysis comparing corresponding weekdays");
 
-            new Option<bool>(
-                aliases: ["--day-of-week-averages", "-dowa"],
-                description: "Show day of week averages comparing cost trends by weekday"),
+        var dayOfWeekOption = new Option<bool>(
+            aliases: ["--day-of-week-averages", "-dowa"],
+            description: "Show day of week averages comparing cost trends by weekday");
 
-            new Option<int?>(
-                aliases: ["--previous-day-utc-data-load-delay", "-pdl"],
-                description: "Number of hours after midnight UTC used to determine when the previous day's Azure cost data is considered complete enough to load. For example, a value of 4 means data for the previous day is assumed complete at 04:00 UTC. Valid values: 0–23.")
-        );
+        var dataLoadDelayOption = new Option<int?>(
+            aliases: ["--previous-day-utc-data-load-delay", "-pdl"],
+            description: "Number of hours after midnight UTC used to determine when the previous day's Azure cost data is considered complete enough to load. For example, a value of 4 means data for the previous day is assumed complete at 04:00 UTC. Valid values: 0–23. Setting this persists for current and future executions.")
+        {
+            ArgumentHelpName = "int:0-23"
+        };
+
+        return (dateOption, weeklyPatternOption, dayOfWeekOption, dataLoadDelayOption);
     }
 
     private static async Task ExecuteCommandAsync(

--- a/AzureDailyCostCompare/CommandLineBuilder.cs
+++ b/AzureDailyCostCompare/CommandLineBuilder.cs
@@ -1,0 +1,82 @@
+﻿using System.CommandLine;
+
+namespace AzureDailyCostCompare;
+
+public static class CommandLineBuilder
+{
+    public static RootCommand BuildCommandLine(int cutoffHourUtc, ConfigurationService configService)
+    {
+        var rootCommand = new RootCommand("Azure Daily Cost Comparison Tool") { Name = "azure-daily-cost-compare" };
+
+        var dateOption = new Option<DateTime?>(
+            "--date",
+            "Optional reference date for the report (format: yyyy-MM-dd). If not provided, current date will be used.");
+        var weeklyPatternOption = new Option<bool>(
+            ["--weekly-pattern-analysis", "-wpa"],
+            "Show weekly pattern analysis comparing corresponding weekdays");
+        var dayOfWeekOption = new Option<bool>(
+            ["--day-of-week-averages", "-dowa"],
+            "Show day of week averages comparing cost trends by weekday");
+
+        var previousDayUtcDataLoadDelayHoursOption = new Option<int?>(
+            ["--previous-day-utc-data-load-delay", "-pdl"],
+            "Number of hours after midnight UTC used to determine when the previous day's Azure cost data is considered complete enough to load. For example, a value of 4 means data for the previous day is assumed complete at 04:00 UTC. Valid values: 0–23.");
+
+        rootCommand.AddOption(dateOption);
+        rootCommand.AddOption(weeklyPatternOption);
+        rootCommand.AddOption(dayOfWeekOption);
+        rootCommand.AddOption(previousDayUtcDataLoadDelayHoursOption);
+
+        rootCommand.SetHandler(async (DateTime? date, bool showWeeklyPatterns, bool showDayOfWeekAverages, int? previousDayUtcDataLoadDelayHours) =>
+        {
+            if (previousDayUtcDataLoadDelayHours.HasValue)
+            {
+                try
+                {
+                    configService.ValidatePreviousDayUtcDataLoadDelayHoursValue(previousDayUtcDataLoadDelayHours.Value);
+                    configService.UpdatePreviousDayUtcDataLoadDelayHours(previousDayUtcDataLoadDelayHours.Value);
+
+                    Console.ForegroundColor = ConsoleColor.Green;
+                    Console.WriteLine($"PreviousDayUtcDataLoadDelayHours value successfully updated to {previousDayUtcDataLoadDelayHours.Value} in {ConfigurationService.ConfigFileName} and will be used on next application execution.");
+                    Console.ResetColor();
+
+                }
+                catch (ConfigurationValidationException ex)
+                {
+                    Console.ForegroundColor = ConsoleColor.Red;
+                    Console.Error.WriteLine($"Error: {ex.Message}");
+                    Console.ResetColor();
+                    return;
+                }
+            }
+
+            // Then run the cost comparison if no validation errors
+            await RunCostComparisonAsync(date, showWeeklyPatterns, showDayOfWeekAverages, previousDayUtcDataLoadDelayHours!.Value);
+        }, dateOption, weeklyPatternOption, dayOfWeekOption, previousDayUtcDataLoadDelayHoursOption);
+
+        return rootCommand;
+    }
+
+    private static async Task RunCostComparisonAsync(DateTime? date, bool showWeeklyPatterns, bool showDayOfWeekAverages, int previousDayUtcDataLoadDelayHours)
+    {
+        try
+        {
+            var accessToken = await AuthenticationService.GetAccessToken();
+            var billingAccountId = await BillingService.GetBillingAccountIdAsync(accessToken);
+            var dateHelper = date.HasValue ? new DateHelperService(previousDayUtcDataLoadDelayHours, date.Value) : new DateHelperService(previousDayUtcDataLoadDelayHours);
+            var costService = new CostService();
+            var costData = await costService.QueryCostManagementAPI(
+                accessToken,
+                billingAccountId,
+                dateHelper.FirstDayOfPreviousMonth,
+                dateHelper.DataReferenceDate);
+            new ReportGenerator(costData, dateHelper).GenerateDailyCostReport(showWeeklyPatterns, showDayOfWeekAverages);
+        }
+        catch (Exception ex)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine($"Error: {ex.Message}");
+            Console.ResetColor();
+        }
+    }
+}

--- a/AzureDailyCostCompare/ConfigurationManager.cs
+++ b/AzureDailyCostCompare/ConfigurationManager.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Nodes;
 
 namespace AzureDailyCostCompare;
 
-public class ConfigurationService
+public static class ConfigurationManager
 {
     public const string ConfigFileName = "appsettings.json";
 

--- a/AzureDailyCostCompare/ConfigurationService.cs
+++ b/AzureDailyCostCompare/ConfigurationService.cs
@@ -8,7 +8,7 @@ public class ConfigurationService
 {
     public const string ConfigFileName = "appsettings.json";
 
-    public IConfiguration LoadConfiguration()
+    public static IConfiguration LoadConfiguration()
     {
         var builder = new ConfigurationBuilder()
             .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
@@ -17,7 +17,7 @@ public class ConfigurationService
         return builder.Build();
     }
 
-    public void ValidatePreviousDayUtcDataLoadDelayHours(IConfiguration configuration)
+    public static void ValidatePreviousDayUtcDataLoadDelayHours(IConfiguration configuration)
     {
         if (!configuration.GetSection("AppSettings:PreviousDayUtcDataLoadDelayHours:Value").Exists())
         {
@@ -32,7 +32,7 @@ public class ConfigurationService
         ValidatePreviousDayUtcDataLoadDelayHoursValue(previousDayUtcDataLoadDelayHours);
     }
 
-    public void ValidatePreviousDayUtcDataLoadDelayHoursValue(int previousDayUtcDataLoadDelayHour)
+    public static void ValidatePreviousDayUtcDataLoadDelayHoursValue(int previousDayUtcDataLoadDelayHour)
     {
         if (previousDayUtcDataLoadDelayHour < 0 || previousDayUtcDataLoadDelayHour > 23)
         {
@@ -40,7 +40,7 @@ public class ConfigurationService
         }
     }
 
-    public void UpdatePreviousDayUtcDataLoadDelayHours(int newPreviousDayUtcDataLoadDelayHours)
+    public static void UpdatePreviousDayUtcDataLoadDelayHours(int newPreviousDayUtcDataLoadDelayHours)
     {
         ValidatePreviousDayUtcDataLoadDelayHoursValue(newPreviousDayUtcDataLoadDelayHours);
 

--- a/AzureDailyCostCompare/ConfigurationService.cs
+++ b/AzureDailyCostCompare/ConfigurationService.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.Extensions.Configuration;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace AzureDailyCostCompare;
+
+public class ConfigurationService
+{
+    public const string ConfigFileName = "appsettings.json";
+
+    public IConfiguration LoadConfiguration()
+    {
+        var builder = new ConfigurationBuilder()
+            .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
+            .AddJsonFile(ConfigFileName, optional: false, reloadOnChange: false);
+
+        return builder.Build();
+    }
+
+    public void ValidatePreviousDayUtcDataLoadDelayHours(IConfiguration configuration)
+    {
+        if (!configuration.GetSection("AppSettings:PreviousDayUtcDataLoadDelayHours:Value").Exists())
+        {
+            throw new ConfigurationValidationException("Missing required configuration value: AppSettings:PreviousDayUtcDataLoadDelayHours:Value");
+        }
+
+        if (!int.TryParse(configuration["AppSettings:PreviousDayUtcDataLoadDelayHours:Value"], out int previousDayUtcDataLoadDelayHours))
+        {
+            throw new ConfigurationValidationException("PreviousDayUtcDataLoadDelayHours:Value must be an integer");
+        }
+
+        ValidatePreviousDayUtcDataLoadDelayHoursValue(previousDayUtcDataLoadDelayHours);
+    }
+
+    public void ValidatePreviousDayUtcDataLoadDelayHoursValue(int previousDayUtcDataLoadDelayHour)
+    {
+        if (previousDayUtcDataLoadDelayHour < 0 || previousDayUtcDataLoadDelayHour > 23)
+        {
+            throw new ConfigurationValidationException($"PreviousDayUtcDataLoadDelayHours:Value must be between 0 and 23 inclusive, got {previousDayUtcDataLoadDelayHour}");
+        }
+    }
+
+    public void UpdatePreviousDayUtcDataLoadDelayHours(int newPreviousDayUtcDataLoadDelayHours)
+    {
+        ValidatePreviousDayUtcDataLoadDelayHoursValue(newPreviousDayUtcDataLoadDelayHours);
+
+        string configFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ConfigFileName);
+
+        if (!File.Exists(configFilePath))
+        {
+            throw new ConfigurationValidationException($"Configuration file not found: {configFilePath}");
+        }
+
+        try
+        {
+            string json = File.ReadAllText(configFilePath);
+
+            using var document = JsonDocument.Parse(json);
+            var rootElement = document.RootElement;
+
+            var jsonObject = JsonSerializer.Deserialize<JsonNode>(json);
+
+            if (jsonObject!["AppSettings"] == null)
+            {
+                jsonObject["AppSettings"] = new JsonObject();
+            }
+
+            if (jsonObject["AppSettings"]!["PreviousDayUtcDataLoadDelayHours"] == null)
+            {
+                jsonObject!["AppSettings"]!["PreviousDayUtcDataLoadDelayHours"] = new JsonObject();
+            }
+
+            jsonObject["AppSettings"]!["PreviousDayUtcDataLoadDelayHours"]!["Value"] = newPreviousDayUtcDataLoadDelayHours;
+
+            // Write updated JSON back to file with indentation
+            var options = new JsonSerializerOptions
+            {
+                WriteIndented = true
+            };
+            string updatedJson = JsonSerializer.Serialize(jsonObject, options);
+            File.WriteAllText(configFilePath, updatedJson);
+        }
+        catch (Exception ex) when (ex is not ConfigurationValidationException)
+        {
+            throw new ConfigurationValidationException($"Failed to update configuration file: {ex.Message}");
+        }
+    }
+}

--- a/AzureDailyCostCompare/ConfigurationValidationException.cs
+++ b/AzureDailyCostCompare/ConfigurationValidationException.cs
@@ -1,0 +1,8 @@
+﻿namespace AzureDailyCostCompare;
+
+public class ConfigurationValidationException : Exception
+{
+    public ConfigurationValidationException(string message) : base(message)
+    {
+    }
+}

--- a/AzureDailyCostCompare/DateHelperService.cs
+++ b/AzureDailyCostCompare/DateHelperService.cs
@@ -8,12 +8,12 @@ public class DateHelperService
     public int CountOfDaysInPreviousMonth { get; }
     public int CountOfDaysInCurrentMonth { get; }
     public int OutputTableDaysToDisplay { get; private set; }
+    public int FullDayDataCutOffHourUTC { get; private set; }
 
-    public const int FULL_DAY_DATA_CUTOFF_HOUR_UTC = 4; // NOTE 4am is a educated approximation(based on testing) regarding MS Cost API having the full previous days data complete and available
-
-    private DateHelperService(DateTime referenceDate)
+    private DateHelperService(int cutoffHourUtc, DateTime referenceDate)
     {
         DataReferenceDate = referenceDate;
+        FullDayDataCutOffHourUTC = cutoffHourUtc;
 
         FirstDayOfPreviousMonth = new DateTime(referenceDate.Year, referenceDate.Month, 1).AddMonths(-1);
         FirstDayOfCurrentMonth = new DateTime(referenceDate.Year, referenceDate.Month, 1);
@@ -23,15 +23,15 @@ public class DateHelperService
     }
 
     // Constructor for current date
-    public DateHelperService(IDateProvider? dateProvider = null)
-        : this(DetermineDataReferenceDate((dateProvider ?? new UtcDateProvider()).GetCurrentDate()))
+    public DateHelperService(int cutoffHourUtc, IDateProvider? dateProvider = null)
+        : this(cutoffHourUtc, DetermineDataReferenceDate((dateProvider ?? new UtcDateProvider()).GetCurrentDate(), cutoffHourUtc))
     {
         OutputTableDaysToDisplay = DataReferenceDate.Day;
     }
 
     // Constructor for override date
-    public DateHelperService(DateTime overrideDate, IDateProvider? dateProvider = null)
-        : this(AdjustDateForFullMonthInPast(ValidateOverrideDate(overrideDate), (dateProvider ?? new UtcDateProvider()).GetCurrentDate()))
+    public DateHelperService(int cutoffHourUtc, DateTime overrideDate, IDateProvider? dateProvider = null)
+        : this(cutoffHourUtc, AdjustDateForFullMonthInPast(ValidateOverrideDate(overrideDate, cutoffHourUtc), (dateProvider ?? new UtcDateProvider()).GetCurrentDate()))
     {
         var currentDate = (dateProvider ?? new UtcDateProvider()).GetCurrentDate();
 
@@ -64,24 +64,24 @@ public class DateHelperService
                $"------\n";
     }
 
-    private static DateTime DetermineDataReferenceDate(DateTime referenceDateTime)
+    private static DateTime DetermineDataReferenceDate(DateTime referenceDateTime, int cutoffHourUtc)
     {
-        DateTime selectedDate = referenceDateTime.Hour < FULL_DAY_DATA_CUTOFF_HOUR_UTC
+        DateTime selectedDate = referenceDateTime.Hour < cutoffHourUtc
             ? referenceDateTime.Date.AddDays(-2)  // Before cutoff, we don't have full day today so last full day is 2 days ago
             : referenceDateTime.Date.AddDays(-1); // It's after cutoff so yesterday is last full day
 
         return selectedDate.Date;
     }
 
-    private static DateTime ValidateOverrideDate(DateTime overrideDate)
+    private static DateTime ValidateOverrideDate(DateTime overrideDate, int cutoffHourUtc)
     {
-        DateTime latestFullDataDate = DetermineDataReferenceDate(DateTime.UtcNow);
+        DateTime latestFullDataDate = DetermineDataReferenceDate(DateTime.UtcNow, cutoffHourUtc);
 
         if (overrideDate.Date > latestFullDataDate.Date)
         {
             throw new ArgumentException(
                 $"Override date must be on or before {latestFullDataDate:yyyy-MM-dd} " +
-                $"to ensure full data availability (based on {FULL_DAY_DATA_CUTOFF_HOUR_UTC} o'clock UTC cutoff).",
+                $"to ensure full data availability (based on {cutoffHourUtc} o'clock UTC cutoff).",
                 nameof(overrideDate));
         }
 
@@ -101,8 +101,8 @@ public class DateHelperService
         return overrideDate;
     }
 
-    public static DateHelperService CreateForTesting(int year, int month, int day)
+    public static DateHelperService CreateForTesting(int cutoffHourUtc, int year, int month, int day)
     {
-        return new DateHelperService(new DateTime(year, month, day));
+        return new DateHelperService(cutoffHourUtc, new DateTime(year, month, day));
     }
 }

--- a/AzureDailyCostCompare/DateHelperService.cs
+++ b/AzureDailyCostCompare/DateHelperService.cs
@@ -8,12 +8,12 @@ public class DateHelperService
     public int CountOfDaysInPreviousMonth { get; }
     public int CountOfDaysInCurrentMonth { get; }
     public int OutputTableDaysToDisplay { get; private set; }
-    public int FullDayDataCutOffHourUTC { get; private set; }
+    public int PreviousDayUtcDataLoadDelayHours { get; private set; }
 
     private DateHelperService(int cutoffHourUtc, DateTime referenceDate)
     {
         DataReferenceDate = referenceDate;
-        FullDayDataCutOffHourUTC = cutoffHourUtc;
+        PreviousDayUtcDataLoadDelayHours = cutoffHourUtc;
 
         FirstDayOfPreviousMonth = new DateTime(referenceDate.Year, referenceDate.Month, 1).AddMonths(-1);
         FirstDayOfCurrentMonth = new DateTime(referenceDate.Year, referenceDate.Month, 1);

--- a/AzureDailyCostCompare/Program.cs
+++ b/AzureDailyCostCompare/Program.cs
@@ -1,5 +1,4 @@
 ﻿using System.CommandLine;
-using System.CommandLine.Parsing;
 using Microsoft.Extensions.Configuration;
 
 namespace AzureDailyCostCompare;
@@ -10,12 +9,14 @@ class Program
     {
         try
         {
-            IConfiguration configuration = LoadAndValidateConfiguration();
+            var configService = new ConfigurationService();
+            IConfiguration configuration = configService.LoadConfiguration();
+            
+            configService.ValidatePreviousDayUtcDataLoadDelayHours(configuration);
 
-            // Cutoff hour setting has been validated
-            int cutoffHourUtc = configuration.GetValue<int>("AppSettings:FullDayDataCutOffHourUTC:Value");
+            int previousDayUtcDataLoadDelayHours = configuration.GetValue<int>("AppSettings:PreviousDayUtcDataLoadDelayHours:Value");
 
-            var rootCommand = BuildCommandLine(cutoffHourUtc);
+            var rootCommand = CommandLineBuilder.BuildCommandLine(previousDayUtcDataLoadDelayHours, configService);
             return await rootCommand.InvokeAsync(args);
         }
         catch (ConfigurationValidationException ex)
@@ -33,76 +34,4 @@ class Program
             return 1;
         }
     }
-
-    private static IConfiguration LoadAndValidateConfiguration()
-    {
-        var builder = new ConfigurationBuilder()
-            .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
-            .AddJsonFile("appsettings.json", optional: false, reloadOnChange: false);
-
-        IConfiguration configuration = builder.Build();
-
-        if (!configuration.GetSection("AppSettings:FullDayDataCutOffHourUTC:Value").Exists())
-        {
-            throw new ConfigurationValidationException("Missing required configuration value: AppSettings:FullDayDataCutOffHourUTC:Value");
-        }
-
-        if (!int.TryParse(configuration["AppSettings:FullDayDataCutOffHourUTC:Value"], out int cutoffHour))
-        {
-            throw new ConfigurationValidationException("FullDayDataCutOffHourUTC:Value must be an integer");
-        }
-
-        if (cutoffHour < 0 || cutoffHour > 23)
-        {
-            throw new ConfigurationValidationException($"FullDayDataCutOffHourUTC:Value must be between 0 and 23 inclusive, got {cutoffHour}");
-        }
-
-        return configuration;
-    }
-
-    private static RootCommand BuildCommandLine(int cutoffHourUtc)
-    {
-        var dateOption = new Option<DateTime?>(
-            "--date",
-            "Optional reference date for the report (format: yyyy-MM-dd). If not provided, current date will be used.");
-        var weeklyPatternOption = new Option<bool>(
-            ["--weekly-pattern-analysis", "-wpa"],
-            "Show Weekly Pattern Analysis comparing corresponding weekdays");
-        var dayOfWeekOption = new Option<bool>(
-            ["--day-of-week-averages", "-dowa"],
-            "Show Day of Week Averages comparing cost trends by weekday");
-        var rootCommand = new RootCommand("Azure Daily Cost Comparison Tool") { Name = "azure-daily-cost-compare" };
-        rootCommand.AddOption(dateOption);
-        rootCommand.AddOption(weeklyPatternOption);
-        rootCommand.AddOption(dayOfWeekOption);
-        rootCommand.SetHandler(async (DateTime? date, bool showWeeklyPatterns, bool showDayOfWeekAverages) =>
-            await RunCostComparisonAsync(date, showWeeklyPatterns, showDayOfWeekAverages, cutoffHourUtc),
-            dateOption, weeklyPatternOption, dayOfWeekOption);
-        return rootCommand;
-    }
-
-    private static async Task RunCostComparisonAsync(DateTime? date, bool showWeeklyPatterns, bool showDayOfWeekAverages, int cutoffHourUtc)
-    {
-        try
-        {
-            var accessToken = await AuthenticationService.GetAccessToken();
-            var billingAccountId = await BillingService.GetBillingAccountIdAsync(accessToken);
-            var dateHelper = date.HasValue ? new DateHelperService(cutoffHourUtc, date.Value) : new DateHelperService(cutoffHourUtc);
-            var costService = new CostService();
-            var costData = await costService.QueryCostManagementAPI(
-                accessToken,
-                billingAccountId,
-                dateHelper.FirstDayOfPreviousMonth,
-                dateHelper.DataReferenceDate);
-            new ReportGenerator(costData, dateHelper).GenerateDailyCostReport(showWeeklyPatterns, showDayOfWeekAverages);
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"Error: {ex.Message}");
-        }
-    }
-}
-
-public class ConfigurationValidationException(string message) : Exception(message)
-{
 }

--- a/AzureDailyCostCompare/Program.cs
+++ b/AzureDailyCostCompare/Program.cs
@@ -9,14 +9,7 @@ class Program
     {
         try
         {
-            var configService = new ConfigurationService();
-            IConfiguration configuration = configService.LoadConfiguration();
-            
-            configService.ValidatePreviousDayUtcDataLoadDelayHours(configuration);
-
-            int previousDayUtcDataLoadDelayHours = configuration.GetValue<int>("AppSettings:PreviousDayUtcDataLoadDelayHours:Value");
-
-            var rootCommand = CommandLineBuilder.BuildCommandLine(previousDayUtcDataLoadDelayHours, configService);
+            var rootCommand = CommandLineBuilder.BuildCommandLine();
             return await rootCommand.InvokeAsync(args);
         }
         catch (ConfigurationValidationException ex)

--- a/AzureDailyCostCompare/Program.cs
+++ b/AzureDailyCostCompare/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System.CommandLine;
 using System.CommandLine.Parsing;
+using Microsoft.Extensions.Configuration;
 
 namespace AzureDailyCostCompare;
 
@@ -7,51 +8,92 @@ class Program
 {
     static async Task<int> Main(string[] args)
     {
-        var rootCommand = BuildCommandLine();
-        return await rootCommand.InvokeAsync(args);
+        try
+        {
+            IConfiguration configuration = LoadAndValidateConfiguration();
+
+            // Cutoff hour setting has been validated
+            int cutoffHourUtc = configuration.GetValue<int>("AppSettings:FullDayDataCutOffHourUTC:Value");
+
+            var rootCommand = BuildCommandLine(cutoffHourUtc);
+            return await rootCommand.InvokeAsync(args);
+        }
+        catch (ConfigurationValidationException ex)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.Error.WriteLine($"Configuration error: {ex.Message}");
+            Console.ResetColor();
+            return 1; // Return non-zero exit code to indicate error
+        }
+        catch (Exception ex)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.Error.WriteLine($"Unexpected error: {ex.Message}");
+            Console.ResetColor();
+            return 1;
+        }
     }
 
-    private static RootCommand BuildCommandLine()
+    private static IConfiguration LoadAndValidateConfiguration()
+    {
+        var builder = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true);
+
+        IConfiguration configuration = builder.Build();
+
+        if (!configuration.GetSection("AppSettings:FullDayDataCutOffHourUTC:Value").Exists())
+        {
+            throw new ConfigurationValidationException("Missing required configuration value: AppSettings:FullDayDataCutOffHourUTC:Value");
+        }
+
+        if (!int.TryParse(configuration["AppSettings:FullDayDataCutOffHourUTC:Value"], out int cutoffHour))
+        {
+            throw new ConfigurationValidationException("FullDayDataCutOffHourUTC:Value must be an integer");
+        }
+
+        if (cutoffHour < 0 || cutoffHour > 23)
+        {
+            throw new ConfigurationValidationException($"FullDayDataCutOffHourUTC:Value must be between 0 and 23 inclusive, got {cutoffHour}");
+        }
+
+        return configuration;
+    }
+
+    private static RootCommand BuildCommandLine(int cutoffHourUtc)
     {
         var dateOption = new Option<DateTime?>(
             "--date",
             "Optional reference date for the report (format: yyyy-MM-dd). If not provided, current date will be used.");
-
         var weeklyPatternOption = new Option<bool>(
             ["--weekly-pattern-analysis", "-wpa"],
             "Show Weekly Pattern Analysis comparing corresponding weekdays");
-
         var dayOfWeekOption = new Option<bool>(
             ["--day-of-week-averages", "-dowa"],
             "Show Day of Week Averages comparing cost trends by weekday");
-
         var rootCommand = new RootCommand("Azure Daily Cost Comparison Tool") { Name = "azure-daily-cost-compare" };
         rootCommand.AddOption(dateOption);
         rootCommand.AddOption(weeklyPatternOption);
         rootCommand.AddOption(dayOfWeekOption);
-
         rootCommand.SetHandler(async (DateTime? date, bool showWeeklyPatterns, bool showDayOfWeekAverages) =>
-            await RunCostComparisonAsync(date, showWeeklyPatterns, showDayOfWeekAverages),
+            await RunCostComparisonAsync(date, showWeeklyPatterns, showDayOfWeekAverages, cutoffHourUtc),
             dateOption, weeklyPatternOption, dayOfWeekOption);
-
         return rootCommand;
     }
 
-    private static async Task RunCostComparisonAsync(DateTime? date, bool showWeeklyPatterns, bool showDayOfWeekAverages)
+    private static async Task RunCostComparisonAsync(DateTime? date, bool showWeeklyPatterns, bool showDayOfWeekAverages, int cutoffHourUtc)
     {
         try
         {
             var accessToken = await AuthenticationService.GetAccessToken();
             var billingAccountId = await BillingService.GetBillingAccountIdAsync(accessToken);
-            var dateHelper = date.HasValue ? new DateHelperService(date.Value) : new DateHelperService();
-
+            var dateHelper = date.HasValue ? new DateHelperService(cutoffHourUtc, date.Value) : new DateHelperService(cutoffHourUtc);
             var costService = new CostService();
             var costData = await costService.QueryCostManagementAPI(
                 accessToken,
                 billingAccountId,
                 dateHelper.FirstDayOfPreviousMonth,
                 dateHelper.DataReferenceDate);
-
             new ReportGenerator(costData, dateHelper).GenerateDailyCostReport(showWeeklyPatterns, showDayOfWeekAverages);
         }
         catch (Exception ex)
@@ -59,4 +101,8 @@ class Program
             Console.WriteLine($"Error: {ex.Message}");
         }
     }
+}
+
+public class ConfigurationValidationException(string message) : Exception(message)
+{
 }

--- a/AzureDailyCostCompare/Program.cs
+++ b/AzureDailyCostCompare/Program.cs
@@ -37,8 +37,8 @@ class Program
     private static IConfiguration LoadAndValidateConfiguration()
     {
         var builder = new ConfigurationBuilder()
-            .SetBasePath(Directory.GetCurrentDirectory())
-            .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true);
+            .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
+            .AddJsonFile("appsettings.json", optional: false, reloadOnChange: false);
 
         IConfiguration configuration = builder.Build();
 

--- a/AzureDailyCostCompare/Properties/launchSettings.json
+++ b/AzureDailyCostCompare/Properties/launchSettings.json
@@ -2,6 +2,10 @@
   "profiles": {
     "AzureDailyCostCompare": {
       "commandName": "Project"
+    },
+    "--previous-day-utc-data-load-delay": {
+      "commandName": "Project",
+      "commandLineArgs": "--previous-day-utc-data-load-delay 8"
     }
   }
 }

--- a/AzureDailyCostCompare/ReportGenerator.cs
+++ b/AzureDailyCostCompare/ReportGenerator.cs
@@ -120,7 +120,7 @@ public class ReportGenerator
 
         PrintSectionHeader("Data Reference Information");
         Console.WriteLine($"All costs in USD");
-        Console.WriteLine($"A day's data is considered complete {DateHelperService.FULL_DAY_DATA_CUTOFF_HOUR_UTC} hours after the end of the day in UTC time.");
+        Console.WriteLine($"A day's data is considered complete {dateHelperService.FullDayDataCutOffHourUTC} hours after the end of the day in UTC time.");
         PrintDataReferenceDetails(dateHelperService.DataReferenceDate, localDataReferenceDay, localTimeZone);
     }
 

--- a/AzureDailyCostCompare/ReportGenerator.cs
+++ b/AzureDailyCostCompare/ReportGenerator.cs
@@ -120,7 +120,7 @@ public class ReportGenerator
 
         PrintSectionHeader("Data Reference Information");
         Console.WriteLine($"All costs in USD");
-        Console.WriteLine($"A day's data is considered complete {dateHelperService.FullDayDataCutOffHourUTC} hours after the end of the day in UTC time.");
+        Console.WriteLine($"A day's data is considered complete {dateHelperService.PreviousDayUtcDataLoadDelayHours} hours after the end of the day in UTC time.");
         PrintDataReferenceDetails(dateHelperService.DataReferenceDate, localDataReferenceDay, localTimeZone);
     }
 

--- a/AzureDailyCostCompare/appsettings.json
+++ b/AzureDailyCostCompare/appsettings.json
@@ -1,8 +1,8 @@
 {
   "AppSettings": {
-    "FullDayDataCutOffHourUTC": {
+    "PreviousDayUtcDataLoadDelayHours": {
       "Value": 4,
-      "Description": "The hour in UTC (0-23) when Microsoft Cost API is expected to have the full previous day's data complete and available. Adjust as needed to balance accuracy with timeliness of obtaining the data. Based on testing, 4 UTC (4:00 AM) is an educated approximation for when the previous day's complete data becomes reliably available."
+      "description": "Number of hours after midnight UTC used to determine when the previous day's Azure cost data is considered complete enough to load. For example, a value of 4 means data for the previous day is assumed complete at 04:00 UTC. Valid values: 0–23."
     }
   }
 }

--- a/AzureDailyCostCompare/appsettings.json
+++ b/AzureDailyCostCompare/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "AppSettings": {
+    "FULL_DAY_DATA_CUTOFF_HOUR_UTC": {
+      "Value": 4,
+      "Description": "The hour in UTC (0-23) when Microsoft Cost API is expected to have the full previous day's data complete and available. Adjust as needed to balance accuracy with timeliness of obtaining the data. Based on testing, 4 UTC (4:00 AM) is an educated approximation for when the previous day's complete data becomes reliably available."
+    }
+  }
+}

--- a/AzureDailyCostCompare/appsettings.json
+++ b/AzureDailyCostCompare/appsettings.json
@@ -1,6 +1,6 @@
 {
   "AppSettings": {
-    "FULL_DAY_DATA_CUTOFF_HOUR_UTC": {
+    "FullDayDataCutOffHourUTC": {
       "Value": 4,
       "Description": "The hour in UTC (0-23) when Microsoft Cost API is expected to have the full previous day's data complete and available. Adjust as needed to balance accuracy with timeliness of obtaining the data. Based on testing, 4 UTC (4:00 AM) is an educated approximation for when the previous day's complete data becomes reliably available."
     }

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This report was generated at 08/01/2025 8:17:17 AM UTC
 
 ## Features
 
-- **Billing Account Scope:** Compare costs across subscriptions within a single billing account.
+- **Billing Account Scope:** Compare costs across Azure subscriptions and Azure tenants within a single Azure billing account.
 - **Daily Cost Comparison:** Compare the costs for each day between two months.
 - **Monthly Average Analysis:** Calculate and display the monthly cost averages.
 - **Cost Delta Calculation:** Highlight the difference in costs between the months.


### PR DESCRIPTION
Closes #5 

Reworked variable naming to be more descriptive
FULL_DAY_DATA_CUTOFF_HOUR_UTC becomes PreviousDayUtcDataLoadDelayHours
Added an appsettings.json to persist the PreviousDayUtcDataLoadDelayHours
Added a command line parameter to set PreviousDayUtcDataLoadDelayHours
Command line parameter persists the change to appsettings.json
General refactor to make things more readable - introduce new commandlinebuilder and configuration classes